### PR TITLE
feature: Add option to run ProxLB only on the Proxmox's master node in the cluster.

### DIFF
--- a/.changelogs/1.1.0/40_add_option_to_run_only_on_cluster_master_node.yml
+++ b/.changelogs/1.1.0/40_add_option_to_run_only_on_cluster_master_node.yml
@@ -1,0 +1,2 @@
+added:
+  - Add option to run ProxLB only on the Proxmox's master node in the cluster. [40]

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ The following options can be set in the `proxlb.conf` file:
 | parallel_migrations | 1 | Defines if migrations should be done parallely or sequentially. (default: 1) |
 | ignore_nodes | dummynode01,dummynode02,test* | Defines a comma separated list of nodes to exclude. |
 | ignore_vms | testvm01,testvm02 | Defines a comma separated list of VMs to exclude. (`*` as suffix wildcard or tags are also supported) |
+| master_only | 0 | Defines is this should only be performed (1) on the cluster master node or not (0). (default: 0) |
 | daemon | 1 | Run as a daemon (1) or one-shot (0). (default: 1) |
 | schedule | 24 | Hours to rebalance in hours. (default: 24) |
 | log_verbosity | INFO | Defines the log level (default: CRITICAL) where you can use `INFO`, `WARN` or `CRITICAL` |
@@ -140,6 +141,10 @@ parallel_migrations: 1
 ignore_nodes: dummynode01,dummynode02
 ignore_vms: testvm01,testvm02
 [service]
+# The master_only option might be usuful if running ProxLB on all nodes in a cluster
+# but only a single one should do the balancing. The master node is obtained from the Proxmox
+# HA status.
+master_only: 0
 daemon: 1
 ```
 

--- a/proxlb
+++ b/proxlb
@@ -33,6 +33,7 @@ except ImportError:
 import random
 import re
 import requests
+import socket
 import sys
 import time
 import urllib3
@@ -40,7 +41,7 @@ import urllib3
 
 # Constants
 __appname__ = "ProxLB"
-__version__ = "1.0.0"
+__version__ = "1.1.0b"
 __author__  = "Florian Paul Azim Hoberg <gyptazy@gyptazy.ch> @gyptazy"
 __errors__ = False
 
@@ -187,6 +188,7 @@ def initialize_config_options(config_path):
         ignore_nodes          = config['balancing'].get('ignore_nodes', None)
         ignore_vms            = config['balancing'].get('ignore_vms', None)
         # Service
+        master_only           = config['service'].get('master_only', 0)
         daemon                = config['service'].get('daemon', 1)
         schedule              = config['service'].get('schedule', 24)
         log_verbosity         = config['service'].get('log_verbosity', 'CRITICAL')
@@ -201,8 +203,8 @@ def initialize_config_options(config_path):
         sys.exit(2)
 
     logging.info(f'{info_prefix} Configuration file loaded.')
-    return proxmox_api_host, proxmox_api_user, proxmox_api_pass, proxmox_api_ssl_v, balancing_method, balancing_mode, \
-         balancing_mode_option, balancing_type, balanciness, parallel_migrations, ignore_nodes, ignore_vms, daemon, schedule, log_verbosity
+    return proxmox_api_host, proxmox_api_user, proxmox_api_pass, proxmox_api_ssl_v, balancing_method, balancing_mode, balancing_mode_option, \
+         balancing_type, balanciness, parallel_migrations, ignore_nodes, ignore_vms, master_only, daemon, schedule, log_verbosity
 
 
 def api_connect(proxmox_api_host, proxmox_api_user, proxmox_api_pass, proxmox_api_ssl_v):
@@ -230,6 +232,42 @@ def api_connect(proxmox_api_host, proxmox_api_user, proxmox_api_pass, proxmox_ap
 
     logging.info(f'{info_prefix} API connection succeeded to host: {proxmox_api_host}.')
     return api_object
+
+
+def get_cluster_master(api_object):
+    """ Get the current master of the Proxmox cluster. """
+    error_prefix = 'Error: [cluster-master-getter]:'
+    info_prefix  = 'Info: [cluster-master-getter]:'
+
+    logging.info(f'{info_prefix} Getting master node from cluster.')
+    try:
+        ha_status_object = api_object.cluster().ha().status().manager_status().get()
+        logging.info(f'{info_prefix} Master node: {ha_status_object["manager_status"]["master_node"]}')
+    except urllib3.exceptions.NameResolutionError:
+        logging.critical(f'{error_prefix} Could not resolve the API.')
+        sys.exit(2)
+    except requests.exceptions.ConnectTimeout:
+        logging.critical(f'{error_prefix} Connection time out to API.')
+        sys.exit(2)
+    except requests.exceptions.SSLError:
+        logging.critical(f'{error_prefix} SSL certificate verification failed for API.')
+        sys.exit(2)
+
+    return ha_status_object['manager_status']['master_node']
+
+
+def validate_cluster_master(cluster_master):
+    """ Validate if the current execution node is the cluster master. """
+    info_prefix  = 'Info: [cluster-master-validator]:'
+
+    node_executor_hostname = socket.gethostname()
+    logging.info(f'{info_prefix} Node executor hostname is: {node_executor_hostname}')
+
+    if node_executor_hostname != cluster_master:
+        logging.info(f'{info_prefix} {node_executor_hostname} is not the cluster master ({cluster_master}).')
+        return False
+    else:
+        return True
 
 
 def get_node_statistics(api_object, ignore_nodes):
@@ -834,7 +872,7 @@ def main():
 
     # Parse global config.
     proxmox_api_host, proxmox_api_user, proxmox_api_pass, proxmox_api_ssl_v, balancing_method, balancing_mode, balancing_mode_option, balancing_type, \
-        balanciness, parallel_migrations, ignore_nodes, ignore_vms, daemon, schedule, log_verbosity = initialize_config_options(config_path)
+        balanciness, parallel_migrations, ignore_nodes, ignore_vms, master_only, daemon, schedule, log_verbosity = initialize_config_options(config_path)
 
     # Overwrite logging handler with user defined log verbosity.
     initialize_logger(log_verbosity, update_log_verbosity=True)
@@ -842,6 +880,16 @@ def main():
     while True:
         # API Authentication.
         api_object = api_connect(proxmox_api_host, proxmox_api_user, proxmox_api_pass, proxmox_api_ssl_v)
+
+        # Get master node of cluster and ensure that ProxLB is only performed on the
+        # cluster master node to avoid ongoing rebalancing.
+        if bool(int(master_only)):
+            cluster_master_node = get_cluster_master(api_object)
+            cluster_master = validate_cluster_master(cluster_master_node)
+            # Validate daemon service and skip following tasks when not being the cluster master.
+            if not cluster_master:
+                validate_daemon(daemon, schedule)
+                continue
 
         # Get metric & statistics for vms and nodes.
         node_statistics = get_node_statistics(api_object, ignore_nodes)


### PR DESCRIPTION
feature: Add option to run ProxLB only on the Proxmox's master node in the cluster.

## General

## Tests
Running on a different node:
```
<6> ProxLB: Info: [logger]: Logger verbosity got updated to: INFO.
<4> ProxLB: Warning: [api-connection]: API connection does not verify SSL certificate.
<6> ProxLB: Info: [api-connection]: API connection succeeded to host: 10.10.10.211.
<6> ProxLB: Info: [cluster-master-getter]: Getting master node from cluster.
<6> ProxLB: Info: [cluster-master-getter]: Master node: virt03
<6> ProxLB: Info: [cluster-master-validator]: Node executor hostname is: dev-nfs01
<6> ProxLB: Info: [cluster-master-validator]: dev-nfs01 is not the cluster master (virt03).
<6> ProxLB: Info: [daemon]: Running in daemon mode. Next run in 24 hours.
```


Running on the master node:
```
<6> ProxLB: Info: [logger]: Logger verbosity got updated to: INFO.
<4> ProxLB: Warning: [api-connection]: API connection does not verify SSL certificate.
<6> ProxLB: Info: [api-connection]: API connection succeeded to host: 10.10.10.211.
<6> ProxLB: Info: [cluster-master-getter]: Getting master node from cluster.
<6> ProxLB: Info: [cluster-master-getter]: Master node: virt03
<6> ProxLB: Info: [cluster-master-validator]: Node executor hostname is: virt03
<6> ProxLB: Info: [cluster-master-validator]: virt03 is the cluster master (virt03).
<6> ProxLB: Info: [node-statistics]: Added node virt02.
<6> ProxLB: Info: [node-statistics]: Added node virt01.
<6> ProxLB: Info: [node-statistics]: Added node virt03.
<6> ProxLB: Info: [node-statistics]: Created node statistics.
<6> ProxLB: Info: [api-get-vm-tags]: Got VM/CT tag from API.
<6> ProxLB: Info: [api-get-vm-tags]: Got VM/CT tag from API.
<6> ProxLB: Info: [api-get-vm-tags]: Got VM/CT tag from API.
<6> ProxLB: Info: [api-get-vm-tags]: Got VM/CT tag from API.
<6> ProxLB: Info: [vm-statistics]: Added vm test08-fat01.
<6> ProxLB: Info: [api-get-vm-tags]: Got VM/CT tag from API.
<6> ProxLB: Info: [api-get-vm-tags]: Got VM/CT tag from API.
<6> ProxLB: Info: [api-get-vm-tags]: Got VM/CT tag from API.
<6> ProxLB: Info: [api-get-vm-include-exclude-tags]: Got PLB include group.
<4> ProxLB: Warn: [vm-statistics]: Rebalancing on LXC containers (CT) always requires them to shut down.
<4> ProxLB: Warn: [vm-statistics]: gyp02 is from type CT and cannot be live migrated!
<6> ProxLB: Info: [api-get-vm-tags]: Got VM/CT tag from API.
<6> ProxLB: Info: [api-get-vm-tags]: Got VM/CT tag from API.
<6> ProxLB: Info: [api-get-vm-tags]: Got VM/CT tag from API.
<6> ProxLB: Info: [api-get-vm-include-exclude-tags]: Got PLB include group.
<6> ProxLB: Info: [api-get-vm-tags]: Got VM/CT tag from API.
<6> ProxLB: Info: [vm-statistics]: Added vm test05.
<6> ProxLB: Info: [api-get-vm-tags]: Got VM/CT tag from API.
<4> ProxLB: Warn: [vm-statistics]: Rebalancing on LXC containers (CT) always requires them to shut down.
<4> ProxLB: Warn: [vm-statistics]: ct-fat is from type CT and cannot be live migrated!
<6> ProxLB: Info: [api-get-vm-tags]: Got VM/CT tag from API.
<6> ProxLB: Info: [api-get-vm-tags]: Got VM/CT tag from API.
<6> ProxLB: Info: [vm-statistics]: Added vm test06-gyptazy01.
<6> ProxLB: Info: [api-get-vm-tags]: Got VM/CT tag from API.
<6> ProxLB: Info: [api-get-vm-tags]: Got VM/CT tag from API.
<6> ProxLB: Info: [vm-statistics]: Added vm test09-fat02.
<6> ProxLB: Info: [api-get-vm-tags]: Got VM/CT tag from API.
<6> ProxLB: Info: [api-get-vm-include-exclude-tags]: Got PLB include group.
<6> ProxLB: Info: [api-get-vm-tags]: Got VM/CT tag from API.
<4> ProxLB: Warn: [vm-statistics]: Rebalancing on LXC containers (CT) always requires them to shut down.
<4> ProxLB: Warn: [vm-statistics]: gyp01 is from type CT and cannot be live migrated!
<6> ProxLB: Info: [api-get-vm-tags]: Got VM/CT tag from API.
<6> ProxLB: Info: [vm-statistics]: Created VM statistics.
<4> ProxLB: Warning: [node-update-statistics]: Node virt01 is overprovisioned for memory by 137%.
<4> ProxLB: Warning: [node-update-statistics]: Node virt03 is overprovisioned for memory by 103%.
<4> ProxLB: Warning: [node-update-statistics]: Node virt03 is overprovisioned for disk by 128%.
<6> ProxLB: Info: [node-update-statistics]: Updated node resource assignments by all VMs.
<6> ProxLB: Info: [balancing-method-validation]]: Valid balancing method: memory
<6> ProxLB: Info: [balancing-mode-validation]]: Valid balancing method: used
<6> ProxLB: Info: [balanciness-validation]: Rebalancing for memory is not needed. Highest usage: 66% | Lowest usage: 61%.
<6> ProxLB: Info: [rebalancing-calculator]: Balancing calculations done.
<6> ProxLB: Info: [rebalancing-executor]: No rebalancing needed.
<6> ProxLB: Info: [cli-output-generator-dry-run]: Starting dry-run to rebalance vms to their new nodes.
<6> ProxLB: Info: [cli-output-generator-dry-run]: No rebalancing needed.
<6> ProxLB: Info: [post-validations]: All post-validations succeeded.
<6> ProxLB: Info: [daemon]: Not running in daemon mode. Quitting.
```

## Notes
Requested by: @wkleinhenz 
Fixes: #40