### PR TITLE
fix: Fix daemon timer to use hours instead of minutes.

### DIFF
--- a/.changelogs/1.1.0/45_fix_daemon_timer.yml
+++ b/.changelogs/1.1.0/45_fix_daemon_timer.yml
@@ -1,0 +1,2 @@
+changed:
+  - Fix daemon timer to use hours instead of minutes. [#45]

--- a/proxlb
+++ b/proxlb
@@ -113,7 +113,7 @@ def validate_daemon(daemon, schedule):
 
     if bool(int(daemon)):
         logging.info(f'{info_prefix} Running in daemon mode. Next run in {schedule} hours.')
-        time.sleep(int(schedule) * 60)
+        time.sleep(int(schedule) * 60 * 60)
     else:
         logging.info(f'{info_prefix} Not running in daemon mode. Quitting.')
         sys.exit(0)


### PR DESCRIPTION
fix: Fix daemon timer to use hours instead of minutes.

The option within the configuration file is defined in hours but it gets passed in the code as seconds where it simply gets multiplied by 60. As a result, we're just getting minutes instead of hours and we need to multiply it by additional 60 to reach hours.

Reported by: @mater-345
Fixes: #45