### PR TITLE
Allow migration from local disks

### DIFF
--- a/.changelogs/1.0.5/113_fix_migration_from_local_disk.yml
+++ b/.changelogs/1.0.5/113_fix_migration_from_local_disk.yml
@@ -1,0 +1,2 @@
+fixed:
+  - Fix migration from local disks. [#113]

--- a/proxlb
+++ b/proxlb
@@ -1185,7 +1185,8 @@ def __run_vm_rebalancing(api_object, _vm_vm_statistics, app_args, parallel_migra
                 # Migrate type VM (live migration).
                 if value['type'] == 'vm':
                     logging.info(f'{info_prefix} Rebalancing VM {vm} from node {value["node_parent"]} to node {value["node_rebalance"]}.')
-                    job_id = api_object.nodes(value['node_parent']).qemu(value['vmid']).migrate().post(target=value['node_rebalance'],online=1)
+                    options = {'target': value['node_rebalance'], 'online': 1, 'with-local-disks': 1}
+                    job_id = api_object.nodes(value['node_parent']).qemu(value['vmid']).migrate().post(**options)
 
                 # Migrate type CT (requires restart of container).
                 if value['type'] == 'ct':


### PR DESCRIPTION
Add parameter `with-local-disks=1` to allow migration from local disks.

Otherwise rebalancing fails with error:
```
2024-10-18 10:09:38 can't migrate local disk 'local-ssd:104/vm-104-disk-0.qcow2': can't live migrate attached local disks without with-local-disks option
```