### PR TITLE
Fix maintenance mode when using cli arg and config mode by using the merged list.

### DIFF
--- a/.changelogs/1.0.6/119_fix_maintenance_mode_cli_and_config.yml
+++ b/.changelogs/1.0.6/119_fix_maintenance_mode_cli_and_config.yml
@@ -1,0 +1,2 @@
+fixed:
+  - Fix maintenance mode when using cli arg and config mode by using the merged list (by @CartCaved). [#119]

--- a/proxlb
+++ b/proxlb
@@ -880,7 +880,7 @@ def balancing_vm_maintenance(proxlb_config, app_args, node_statistics, vm_statis
         maintenance_nodes_list = maintenance_nodes_list + app_args.maintenance.split(',')
 
     # Ensure that only existing nodes in the cluster will be used.
-    if len(proxlb_config['vm_maintenance_nodes']) > 1:
+    if len(maintenance_nodes_list) > 1:
         maintenance_nodes_list = set(maintenance_nodes_list) & set(nodes_present)
         logging.info(f'{info_prefix} Maintenance mode for the following hosts defined: {maintenance_nodes_list}')
     else:


### PR DESCRIPTION
Fix maintenance mode when using cli arg and config mode by using the merged list.

Sponsored-by: @CartCaved
Fixes: #119