### PR TITLE
feat: optimize Dockerfile, create docker-compose with build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Use the official Debian 12 base image
-FROM debian:12
+# Use the official Python 3.12 image
+FROM python:3.12
 
 # Labels
 LABEL maintainer="gyptazy@gyptazy.ch"
@@ -7,29 +7,16 @@ LABEL org.label-schema.schema-version="0.9"
 LABEL org.label-schema.description="ProxLB - Rebalance VM workloads across nodes in a Proxmox cluster."
 LABEL org.label-schema.url="https://github.com/gyptazy/ProxLB"
 
-# Set environment variables
-ENV DEBIAN_FRONTEND=noninteractive
-
-# Install python3 and python3-venv
-RUN apt-get update && \
-    apt-get install -y python3 python3-pip python3-venv && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
 # Create a directory for the app
 WORKDIR /app
 
 # Copy the python program from the current directory to /app
 COPY proxlb /app/proxlb
 
-# Create a virtual environment
-RUN python3 -m venv venv
-
 # Copy requirements to the container
 COPY requirements.txt /app/requirements.txt
 
-# Install dependencies in the virtual environment
-RUN . venv/bin/activate && pip install -r /app/requirements.txt
+RUN pip install -r /app/requirements.txt
 
 # Set the entry point to use the virtual environment's python
-ENTRYPOINT ["/app/venv/bin/python3", "/app/proxlb"]
+ENTRYPOINT ["python3", "/app/proxlb"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  proxlb:
+    build: .
+    volumes:
+      - ./proxlb.conf:/etc/proxlb/proxlb.conf
+    restart: unless-stopped
+    container_name: proxlb


### PR DESCRIPTION
Used a smaller base in the dockerfile with python already installed. Only copied over the files and installed requirements instead of the whole python venv and apt updates. This way, I reduced the build time from ~3 minutes to just ~30 seconds (on my environment). 
Added a docker compose file which builds the Dockerfile locally and also attaches the proxlb.conf file. 