### PR TITLE
fix: systemd service install target

### DIFF
--- a/.changelogs/1.0.7/135_fix_systemd_service_install_target.yml
+++ b/.changelogs/1.0.7/135_fix_systemd_service_install_target.yml
@@ -1,0 +1,2 @@
+fixed:
+  - Fix systemd service file missing install target and network requirements (by @thomasfinstad). [#135]

--- a/docs/01_Installation.md
+++ b/docs/01_Installation.md
@@ -8,7 +8,8 @@ wget https://cdn.gyptazy.ch/files/amd64/debian/proxlb/proxlb_0.9.9_amd64.deb
 dpkg -i proxlb_0.9.9_amd64.deb
 # Adjust your config
 vi /etc/proxlb/proxlb.conf
-systemctl restart proxlb
+# Enable and start the service
+systemctl enable --now proxlb
 systemctl status proxlb
 ```
 

--- a/packaging/proxlb.service
+++ b/packaging/proxlb.service
@@ -1,6 +1,11 @@
 [Unit]
 Description=ProxLB - Rebalance VM workloads
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 ExecStart=/usr/bin/proxlb -c /etc/proxlb/proxlb.conf
 User=plb
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Adds network requirements and install target to systemd service file.
Fixes #135 