### PR TITLE
feature: Add Proxmox API token authentication

### DIFF
--- a/.changelogs/1.1.0/125-add-proxmox-api-authentication-support.yml
+++ b/.changelogs/1.1.0/125-add-proxmox-api-authentication-support.yml
@@ -1,0 +1,2 @@
+feature:
+  - Add Proxmox API authentication support. [#125]

--- a/README.md
+++ b/README.md
@@ -141,7 +141,9 @@ The following options can be set in the configuration file `proxlb.yaml`:
 | `proxmox_api` |  |  | |  |
 | | hosts | ['virt01.example.com', '10.10.10.10', 'fe01::bad:code::cafe'] | `List` | List of Proxmox nodes. Can be IPv4, IPv6 or mixed. |
 | | user | root@pam | `Str` | Username for the API. |
-| | pass | FooBar | `Str` | Password for the API. |
+| | pass | FooBar | `Str` | Password for the API. (Recommended: Use API token authorization!) |
+| | token_id | proxlb | `Str` | Token ID of the user for the API. |
+| | token_secret | 430e308f-1337-1337-beef-1337beefcafe | `Str` | Secret of the token ID for the API. |
 | | ssl_verification | True | `Bool` | Validate SSL certificates (1) or ignore (0). (default: 1, type: bool) |
 | | timeout | 10 | `Int` | Timeout for the Proxmox API in sec. (default: 10) |
 | `proxmox_cluster` |  | | |  |
@@ -169,7 +171,9 @@ An example of the configuration file looks like:
 proxmox_api:
   hosts: ['virt01.example.com', '10.10.10.10', 'fe01::bad:code::cafe']
   user: root@pam
-  pass: crazyPassw0rd!
+  #pass: crazyPassw0rd!
+  token_id: proxlb
+  token_secret: 430e308f-1337-1337-beef-1337beefcafe
   ssl_verification: False
   timeout: 10
 

--- a/config/proxlb_example.yaml
+++ b/config/proxlb_example.yaml
@@ -2,6 +2,9 @@ proxmox_api:
   hosts: ['virt01.example.com', '10.10.10.10', 'fe01::bad:code::cafe']
   user: root@pam
   pass: crazyPassw0rd!
+  # API Token method
+  # token_id: proxlb
+  # token_secret: 430e308f-1337-1337-beef-1337beefcafe
   ssl_verification: False
   timeout: 10
 

--- a/proxlb/utils/proxmox_api.py
+++ b/proxlb/utils/proxmox_api.py
@@ -267,12 +267,24 @@ class ProxmoxApi:
 
         # Login into Proxmox API and create API object
         try:
-            proxmox_api = proxmoxer.ProxmoxAPI(
-                proxmox_api_endpoint,
-                user=proxlb_config.get("proxmox_api").get("user", True),
-                password=proxlb_config.get("proxmox_api").get("pass", True),
-                verify_ssl=proxlb_config.get("proxmox_api").get("ssl_verification", True),
-                timeout=proxlb_config.get("proxmox_api").get("timeout", True))
+
+            if proxlb_config.get("proxmox_api").get("token_secret", False):
+                proxmox_api = proxmoxer.ProxmoxAPI(
+                    proxmox_api_endpoint,
+                    user=proxlb_config.get("proxmox_api").get("user", True),
+                    token_name=proxlb_config.get("proxmox_api").get("token_id", True),
+                    token_value=proxlb_config.get("proxmox_api").get("token_secret", True),
+                    verify_ssl=proxlb_config.get("proxmox_api").get("ssl_verification", True),
+                    timeout=proxlb_config.get("proxmox_api").get("timeout", True))
+                logger.debug("Using API token authentication.")
+            else:
+                proxmox_api = proxmoxer.ProxmoxAPI(
+                    proxmox_api_endpoint,
+                    user=proxlb_config.get("proxmox_api").get("user", True),
+                    password=proxlb_config.get("proxmox_api").get("pass", True),
+                    verify_ssl=proxlb_config.get("proxmox_api").get("ssl_verification", True),
+                    timeout=proxlb_config.get("proxmox_api").get("timeout", True))
+                logger.debug("Using username/password authentication.")
         except proxmoxer.backends.https.AuthenticationError as proxmox_api_error:
             logger.critical(f"Authentication failed. Please check the defined credentials: {proxmox_api_error}")
             sys.exit(2)


### PR DESCRIPTION
feature: Add Proxmox API token authentication

Add support to ProxLB to also support the native Proxmox API authentication by using API tokens instead of username and password.

Fixes: #125