### PR TITLE
adjustment: Rename param `force` to `enforce_affinity`

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ The following options can be set in the configuration file `proxlb.yaml`:
 | | overprovisioning | False | `Bool` | Avoids balancing when nodes would become overprovisioned. |
 | `balancing` |  | | |  |
 | | enable | True | `Bool` | Enables the guest balancing.  (default: True)|
-| | force | True | `Bool` | Enforcing affinity/anti-affinity rules but balancing might become worse.  (default: False) |
+| | enforce_affinity | True | `Bool` | Enforcing affinity/anti-affinity rules but balancing might become worse.  (default: False) |
 | | parallel | False | `Bool` | If guests should be moved in parallel or sequentially. (default: False)|
 | | live | True | `Bool` | If guests should be moved live or shutdown.  (default: True)|
 | | with_local_disks | True | `Bool` | If balancing of guests should include local disks  (default: True)|
@@ -184,7 +184,7 @@ proxmox_cluster:
 
 balancing:
   enable: True
-  force: False
+  enforce_affinity: False
   parallel: False
   live: True
   with_local_disks: True

--- a/config/proxlb_example.yaml
+++ b/config/proxlb_example.yaml
@@ -15,7 +15,7 @@ proxmox_cluster:
 
 balancing:
   enable: True
-  force: False
+  enforce_affinity: False
   parallel: False
   live: True
   with_local_disks: True

--- a/proxlb/models/calculations.py
+++ b/proxlb/models/calculations.py
@@ -207,13 +207,13 @@ class Calculations:
         None
         """
         logger.debug("Starting: relocate_guests.")
-        if proxlb_data["meta"]["balancing"]["balance"] or proxlb_data["meta"]["balancing"]["force"]:
+        if proxlb_data["meta"]["balancing"]["balance"] or proxlb_data["meta"]["balancing"]["enforce_affinity"]:
 
             if proxlb_data["meta"]["balancing"].get("balance", False):
                 logger.debug("Balancing of guests will be performt. Reason: balanciness")
 
-            if proxlb_data["meta"]["balancing"].get("force", False):
-                logger.debug("Balancing of guests will be performt. Reason: force balancing")
+            if proxlb_data["meta"]["balancing"].get("enforce_affinity", False):
+                logger.debug("Balancing of guests will be performt. Reason: enforce affinity balancing")
 
             for group_name in proxlb_data["groups"]["affinity"]:
 


### PR DESCRIPTION
adjustment: Rename param `force` to `enforce_affinity`
  * This change should make the parameter's intention more clear

Fixes: #146 