### PR TITLE
fix: Fix the systemd unit file to start after the pveproxy daemon

### DIFF
--- a/.changelogs/1.1.0/137_fix_systemd_unit_file.yml
+++ b/.changelogs/1.1.0/137_fix_systemd_unit_file.yml
@@ -1,0 +1,2 @@
+fixed:
+  - Fix the systemd unit file to start ProxLB after pveproxy (by @robertdahlem). [#137]

--- a/service/proxlb.service
+++ b/service/proxlb.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=ProxLB - A loadbalancer for Proxmox clusters
-After=network-online.target
-Wants=network-online.target
+After=pveproxy.service
+Wants=pveproxy.service
 
 [Service]
 ExecStart=python3 /usr/lib/python3/dist-packages/proxlb/main.py -c /etc/proxlb/proxlb.yaml


### PR DESCRIPTION
fix: Fix the systemd unit file to start after the pveproxy daemon

Fixed-by: @robertdahlem
Fixes: #137
Fixes: #155