### PR TITLE
fix: Add JSON output again

### DIFF
--- a/proxlb/main.py
+++ b/proxlb/main.py
@@ -74,6 +74,9 @@ def main():
         if not cli_args.dry_run:
             Balancing(proxmox_api, proxlb_data)
 
+        # Validate if the JSON output should be
+        # printed to stdout
+        Helper.print_json(proxlb_data, cli_args.json)
         # Validate daemon mode
         Helper.get_daemon_mode(proxlb_config)
 

--- a/proxlb/models/calculations.py
+++ b/proxlb/models/calculations.py
@@ -207,7 +207,7 @@ class Calculations:
         None
         """
         logger.debug("Starting: relocate_guests.")
-        if proxlb_data["meta"]["balancing"]["balance"] or proxlb_data["meta"]["balancing"]["enforce_affinity"]:
+        if proxlb_data["meta"]["balancing"]["balance"] or proxlb_data["meta"]["balancing"].get("enforce_affinity", False):
 
             if proxlb_data["meta"]["balancing"].get("balance", False):
                 logger.debug("Balancing of guests will be performt. Reason: balanciness")

--- a/proxlb/utils/helper.py
+++ b/proxlb/utils/helper.py
@@ -8,6 +8,7 @@ __copyright__ = "Copyright (C) 2025 Florian Paul Azim Hoberg (@gyptazy)"
 __license__ = "GPL-3.0"
 
 
+import json
 import uuid
 import sys
 import time
@@ -124,3 +125,23 @@ class Helper:
             sys.exit(0)
 
         logger.debug("Finished: get_daemon_mode.")
+
+    @staticmethod
+    def print_json(proxlb_config: Dict[str, Any], print_json: bool = False) -> None:
+        """
+        Prints the calculated balancing matrix as a JSON output to stdout.
+
+        Parameters:
+            proxlb_config (Dict[str, Any]): A dictionary containing the ProxLB configuration.
+
+        Returns:
+            None
+        """
+        logger.debug("Starting: print_json.")
+        if print_json:
+            # Create a filtered list by stripping the 'meta' key from the proxlb_config dictionary
+            # to make sure that no credentials are leaked.
+            filtered_data = {k: v for k, v in proxlb_config.items() if k != "meta"}
+            print(json.dumps(filtered_data, indent=4))
+
+        logger.debug("Finished: print_json.")


### PR DESCRIPTION
fix: Add JSON output again

### Validation
When passing `-j` a json output will be printed to stdout. This looks like:

```
% python3 proxlb/main.py -c ../proxlb.yaml -d -j    
SSL certificate validation to host 10.66.66.66 is deactivated.
Guest balancing is required. Highest value: 12.68458927312864, lowest value: 5.493756799142955 balanced by memory and used.
Node: cbc-kvm16 already got used for anti-affinity group:: plb_anti_affinity_harv. (Tried for guest: test-xn02)
{
    "nodes": {
        "test-c66": {
            "name": "test-c66",
            "maintenance": false,
            "cpu_total": 48,
            "cpu_assigned": 28,
            "cpu_used": 0.03950707090217665,
            "cpu_free": 46.88357655579746,
            "cpu_assigned_percent": 58.333333333333336,
            "cpu_free_percent": 97.67411782457805,
            "cpu_used_percent": 0.08230639771286802,
            "memory_total": 540915605504,
            "memory_assigned": 128094044160,
            "memory_used": 42563733154,
            "memory_free": 504729223168,
            "memory_assigned_percent": 23.68096665294911,
            "memory_free_percent": 93.31016114754478,
            "memory_used_percent": 7.8688306865062785,
            "disk_total": 68781744128,
            "disk_assigned": 629212708864,
            "disk_used": 6539321344,
            "disk_free": 59791310848,
            "disk_assigned_percent": 914.7960942849327,
            "disk_free_percent": 86.92904142810166,
            "disk_used_percent": 9.507350281537775
        },
[...]
```

Fixes: #158