### PR TITLE
fix: Fix tag evluation for VMs for being ignored for further balancing

### DIFF
--- a/.changelogs/1.1.1/163_fix_ignore_vm_tag.yml
+++ b/.changelogs/1.1.1/163_fix_ignore_vm_tag.yml
@@ -1,0 +1,2 @@
+fixed:
+  - Fix tag evluation for VMs for being ignored for further balancing [#163]

--- a/.changelogs/1.1.1/165_improve_logging_servity.yml
+++ b/.changelogs/1.1.1/165_improve_logging_servity.yml
@@ -1,0 +1,2 @@
+fixed:
+  - Improve logging verbosity of messages that had a wrong servity [#165]

--- a/.changelogs/1.1.1/release_meta.yml
+++ b/.changelogs/1.1.1/release_meta.yml
@@ -1,0 +1,1 @@
+date: TBD

--- a/proxlb/models/calculations.py
+++ b/proxlb/models/calculations.py
@@ -119,10 +119,8 @@ class Calculations:
             if method_value_highest - method_value_lowest > balanciness:
                 proxlb_data["meta"]["balancing"]["balance"] = True
                 logger.debug(f"Guest balancing is required. Highest value: {method_value_highest}, lowest value: {method_value_lowest} balanced by {method} and {mode}.")
-                logger.critical(f"Guest balancing is required. Highest value: {method_value_highest}, lowest value: {method_value_lowest} balanced by {method} and {mode}.")
             else:
                 logger.debug(f"Guest balancing is ok. Highest value: {method_value_highest}, lowest value: {method_value_lowest} balanced by {method} and {mode}.")
-                logger.critical(f"Guest balancing is ok. Highest value: {method_value_highest}, lowest value: {method_value_lowest} balanced by {method} and {mode}.")
 
         else:
             logger.warning("No guests for balancing found.")


### PR DESCRIPTION
fix: Fix tag evluation for VMs for being ignored for further balancing

### Test
```
SSL certificate validation to host 10.11.11.11 is deactivated.
Balancing: Guest dummy01 rebalanced.
Balancing: Guest dummy04 is ignored and will not be rebalanced.
Balancing: Guest dummy02 rebalanced.
```

Fixes: #163
Fixes: #165