### PR TITLE
fix: logging handler for no systemd integration

### DIFF
--- a/.changelogs/1.1.1/185-logging-handler-for-no-systemd-integration.yml
+++ b/.changelogs/1.1.1/185-logging-handler-for-no-systemd-integration.yml
@@ -1,0 +1,2 @@
+fix:
+  - add handler to log messages with severity less than info to the screen when there is no systemd integration, for instance, inside a docker container. [#185]

--- a/proxlb/utils/logger.py
+++ b/proxlb/utils/logger.py
@@ -9,6 +9,7 @@ __license__ = "GPL-3.0"
 
 
 import logging
+import sys
 try:
     from systemd.journal import JournalHandler
     SYSTEMD_PRESENT = True
@@ -93,6 +94,15 @@ class SystemdLogger:
             journal_handler.setFormatter(formatter)
             # Add handler to logger
             self.logger.addHandler(journal_handler)
+        else:
+            # Add a handler for no systemd integration
+            handler = logging.StreamHandler(sys.stdout)
+            handler.setLevel(level)
+            # Set a formatter to include the logger's name and log message
+            formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+            handler.setFormatter(formatter)
+            # Add handler to logger
+            self.logger.addHandler(handler)
 
     def set_log_level(self, level: str) -> None:
         """


### PR DESCRIPTION
Add a logging handler for when there is no systemd integration like inside a container.
I'm not sure if this is the best way to do this or not.
fixes: #185