### PR TITLE
fix: allow use of minutes instead of hours

### DIFF
--- a/.changelogs/1.1.1/187_allow_use_of_minutes_instead_of_hours.yml
+++ b/.changelogs/1.1.1/187_allow_use_of_minutes_instead_of_hours.yml
@@ -1,0 +1,2 @@
+fixed:
+  - allow the use of minutes instead of hours and only accept hours or minutes in the format [#187]

--- a/proxlb/utils/helper.py
+++ b/proxlb/utils/helper.py
@@ -124,11 +124,14 @@ class Helper:
                 sys.exit(1)
 
             # Convert hours to seconds
-            if proxlb_config["service"]["schedule"].get("format", "hours"):
+            if proxlb_config["service"]["schedule"].get("format", "hours") == "hours":
                 sleep_seconds = proxlb_config.get("service", {}).get("schedule", {}).get("interval", 12) * 3600
             # Convert minutes to seconds
-            else:
+            elif proxlb_config["service"]["schedule"].get("format", "hours") == "minutes":
                 sleep_seconds = proxlb_config.get("service", {}).get("schedule", {}).get("interval", 720) * 60
+            else:
+                logger.error("Invalid format for schedule. Please use 'hours' or 'minutes'.")
+                sys.exit(1)
 
             logger.info(f"Daemon mode active: Next run in: {proxlb_config.get('service', {}).get('schedule', {}).get('interval', 12)} {proxlb_config['service']['schedule'].get('format', 'hours')}.")
             time.sleep(sleep_seconds)


### PR DESCRIPTION
Allow use of minutes instead of hours.
Also, validate the field format in the config file is minutes or hours.
fixes #187 