### PR TITLE
fix: set cpu_used to be cpu usage times number of cpu cores

### DIFF
--- a/.changelogs/1.1.1/195_set_cpu_used_to_cpu_usage_times_core_count.yml
+++ b/.changelogs/1.1.1/195_set_cpu_used_to_cpu_usage_times_core_count.yml
@@ -1,0 +1,2 @@
+fixed:
+  - Set cpu_used to the cpu usage, which is a percent, times the total number of cores to get a number where guest cpu_used can be added to nodes cpu_used and be meaningful (by @glitchvern) [#195]

--- a/proxlb/models/guests.py
+++ b/proxlb/models/guests.py
@@ -64,7 +64,7 @@ class Guests:
                     guests['guests'][guest['name']] = {}
                     guests['guests'][guest['name']]['name'] = guest['name']
                     guests['guests'][guest['name']]['cpu_total'] = guest['cpus']
-                    guests['guests'][guest['name']]['cpu_used'] = guest['cpu']
+                    guests['guests'][guest['name']]['cpu_used'] = guest['cpu'] * guest['cpus']
                     guests['guests'][guest['name']]['memory_total'] = guest['maxmem']
                     guests['guests'][guest['name']]['memory_used'] = guest['mem']
                     guests['guests'][guest['name']]['disk_total'] = guest['maxdisk']

--- a/proxlb/models/nodes.py
+++ b/proxlb/models/nodes.py
@@ -63,7 +63,7 @@ class Nodes:
                 nodes["nodes"][node["node"]]["maintenance"] = False
                 nodes["nodes"][node["node"]]["cpu_total"] = node["maxcpu"]
                 nodes["nodes"][node["node"]]["cpu_assigned"] = 0
-                nodes["nodes"][node["node"]]["cpu_used"] = node["cpu"]
+                nodes["nodes"][node["node"]]["cpu_used"] = node["cpu"] * node["maxcpu"]
                 nodes["nodes"][node["node"]]["cpu_free"] = (node["maxcpu"]) - (node["cpu"] * node["maxcpu"])
                 nodes["nodes"][node["node"]]["cpu_assigned_percent"] = nodes["nodes"][node["node"]]["cpu_assigned"] / nodes["nodes"][node["node"]]["cpu_total"] * 100
                 nodes["nodes"][node["node"]]["cpu_free_percent"] = nodes["nodes"][node["node"]]["cpu_free"] / node["maxcpu"] * 100


### PR DESCRIPTION
Multiplying the cpu usage from the proxmox api by the total cores from the proxmox api gives numbers that can be added/subtracted as guests move from one node to another and then nodes compared to one another.
fixes: #195