### PR TITLE
fix: Use method/mode in configuration to calculate lowest_usage_node

### DIFF
--- a/.changelogs/1.1.1/197_remove_hard_coded_memory_usage_from_lowest_usage_node.yml
+++ b/.changelogs/1.1.1/197_remove_hard_coded_memory_usage_from_lowest_usage_node.yml
@@ -1,0 +1,2 @@
+fixed:
+  - Remove hard coded memory usage from lowest usage node and use method and mode specified in configuration instead (by @glitchvern) [#197]

--- a/proxlb/models/calculations.py
+++ b/proxlb/models/calculations.py
@@ -147,7 +147,9 @@ class Calculations:
 
         # Do not include nodes that are marked in 'maintenance'
         filtered_nodes = [node for node in proxlb_data["nodes"].values() if not node["maintenance"]]
-        lowest_usage_node = min(filtered_nodes, key=lambda x: x["memory_used_percent"])
+        method = proxlb_data["meta"]["balancing"].get("method", "memory")
+        mode = proxlb_data["meta"]["balancing"].get("mode", "used")
+        lowest_usage_node = min(filtered_nodes, key=lambda x: x[f"{method}_{mode}_percent"])
         proxlb_data["meta"]["balancing"]["balance_reason"] = 'resources'
         proxlb_data["meta"]["balancing"]["balance_next_node"] = lowest_usage_node["name"]
 


### PR DESCRIPTION
Use method and mode specified in configuration to calculate lowest_usage_node.

By itself this change does little but combined with pull request #196 results in better balancing.