### PR TITLE
fix: Requery the guests if a running guest reports 0 cpu usage

### DIFF
--- a/.changelogs/1.1.1/200_requery_zero_guest_cpu_used.yml
+++ b/.changelogs/1.1.1/200_requery_zero_guest_cpu_used.yml
@@ -1,0 +1,2 @@
+fixed:
+  - Requery the guests if a running guest reports 0 cpu usage (by @glitchvern) [#200]


### PR DESCRIPTION
Requery the guests if a running guest reports 0 cpu usage.  Even an idle guest should have some small amount of cpu usage.

This sleeps 10 seconds before requerying the guests.  It will do this repeatedly until none of the guests report 0 percent cpu usage.  This can take a few tries.  This might be a problem.  If a guest is manually migrated between the time ProxLB gets the usages from the nodes and when it attempts the actual rebalancing, ProxLB can attempt to migrate a guest from a node it isn't on.  This causes a crash of ProxLB.  I think the actual problem might be in the proxmoxer library that allows you to attempt to move a guest from a node it isn't on and then crashes when you try it.

With this pull request the cpu load on an unbalanced cluster is quickly balanced after only a few rebalancing intervals.

I didn't experiment with sleeps different than 10 seconds.  It's possible a shorter sleep might be better.

I also didn't experiment with trying to requery only the guest which reported 0 percent cpu usage.