### PR TITLE
fix: Requery a guest if that running guest reports 0 cpu usage

### DIFF
--- a/.changelogs/1.1.1/200_requery_zero_guest_cpu_used.yml
+++ b/.changelogs/1.1.1/200_requery_zero_guest_cpu_used.yml
@@ -1,0 +1,2 @@
+fixed:
+  - Requery a guest if that running guest reports 0 cpu usage (by @glitchvern) [#200]

--- a/proxlb/models/guests.py
+++ b/proxlb/models/guests.py
@@ -62,11 +62,13 @@ class Guests:
             # resource metrics for rebalancing to ensure that we do not overprovisiong the node.
             for guest in proxmox_api.nodes(node).qemu.get():
                 if guest['status'] == 'running':
-                    while guest['cpu'] == 0:
+                    retry_counter = 1
+                    while guest['cpu'] == 0 and retry_counter < 10:
                         guest = proxmox_api.nodes(node).qemu(guest['vmid']).status.current.get()
                         logger.debug(f"guest {guest['name']} is reporting {
-guest['cpu']} cpu usage.")
+guest['cpu']} cpu usage on retry {retry_counter}.")
                         time.sleep(1)
+                        retry_counter += 1
                     guests['guests'][guest['name']] = {}
                     guests['guests'][guest['name']]['name'] = guest['name']
                     guests['guests'][guest['name']]['cpu_total'] = guest['cpus']

--- a/proxlb/models/guests.py
+++ b/proxlb/models/guests.py
@@ -11,6 +11,7 @@ __license__ = "GPL-3.0"
 from typing import Dict, Any
 from utils.logger import SystemdLogger
 from models.tags import Tags
+import time
 
 logger = SystemdLogger()
 
@@ -61,6 +62,11 @@ class Guests:
             # resource metrics for rebalancing to ensure that we do not overprovisiong the node.
             for guest in proxmox_api.nodes(node).qemu.get():
                 if guest['status'] == 'running':
+                    while guest['cpu'] == 0:
+                        guest = proxmox_api.nodes(node).qemu(guest['vmid']).status.current.get()
+                        logger.debug(f"guest {guest['name']} is reporting {
+guest['cpu']} cpu usage.")
+                        time.sleep(1)
                     guests['guests'][guest['name']] = {}
                     guests['guests'][guest['name']]['name'] = guest['name']
                     guests['guests'][guest['name']]['cpu_total'] = guest['cpus']


### PR DESCRIPTION
Requery a guest if that running guest reports 0 cpu usage. Even an idle guest should have some small amount of cpu usage.

This one is a bit tighter than the last pull request.  Here we only requery the guests that have 0 percent cpu usage instead of requerying all the guests on a node.  We also only sleep for 1 second instead of 10 seconds.  Some of the 0 percent cpu usage guests sometimes have to be requeried multiple times and others get cpu usage on the first requery.  This results in more sleeps of shorter duration than the last pull request.  This still results in some delay between when the nodes are queried and when the guests are actually rebalanced.  A sufficiently long delay could allow a manual migration to be started and completed followed by ProxLB attempting to move the guest from a node it isn't on resulting in a crash.