### PR TITLE
fix: Adjust the systemd unit file to run after the network target on non PVE nodes

### DIFF
--- a/.changelogs/1.1.2/137_fix_systemd_unit_file.yml
+++ b/.changelogs/1.1.2/137_fix_systemd_unit_file.yml
@@ -1,0 +1,2 @@
+fixed:
+  - Fix systemd unit file to run after network on non PVE nodes (by @robertdahlem) [#137]

--- a/service/proxlb.service
+++ b/service/proxlb.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=ProxLB - A loadbalancer for Proxmox clusters
-After=pveproxy.service
-Wants=pveproxy.service
+After=network-online.target pveproxy.service
+Wants=network-online.target pveproxy.service
 
 [Service]
 ExecStart=python3 /usr/lib/python3/dist-packages/proxlb/main.py -c /etc/proxlb/proxlb.yaml


### PR DESCRIPTION
fix: Adjust the systemd unit file to run after the network target on non PVE nodes

Fixes: #137