### PR TITLE
fix: Force type cast guest cpu count to int where in some corner cases a str got returned.

### DIFF
--- a/.changelogs/1.1.2/222_fix_force_type_cast_cpu_metrics_to_int.yml
+++ b/.changelogs/1.1.2/222_fix_force_type_cast_cpu_metrics_to_int.yml
@@ -1,0 +1,2 @@
+fixed:
+  - Force type cast cpu count of guests to int for some corner cases where a str got returned (by @gyptazy). [#222]

--- a/proxlb/models/calculations.py
+++ b/proxlb/models/calculations.py
@@ -82,6 +82,7 @@ class Calculations:
                 guest_node_current = proxlb_data["guests"][guest_name]["node_current"]
                 # Update Hardware assignments
                 # Update assigned values for the current node
+                logger.debug(f"set_node_assignment of guest {guest_name} on node {guest_node_current} with cpu_total: {proxlb_data['guests'][guest_name]['cpu_total']}, memory_total: {proxlb_data['guests'][guest_name]['memory_total']}, disk_total: {proxlb_data['guests'][guest_name]['disk_total']}.")
                 proxlb_data["nodes"][guest_node_current]["cpu_assigned"] += proxlb_data["guests"][guest_name]["cpu_total"]
                 proxlb_data["nodes"][guest_node_current]["memory_assigned"] += proxlb_data["guests"][guest_name]["memory_total"]
                 proxlb_data["nodes"][guest_node_current]["disk_assigned"] += proxlb_data["guests"][guest_name]["disk_total"]

--- a/proxlb/models/guests.py
+++ b/proxlb/models/guests.py
@@ -76,7 +76,7 @@ class Guests:
 
                     guests['guests'][guest['name']] = {}
                     guests['guests'][guest['name']]['name'] = guest['name']
-                    guests['guests'][guest['name']]['cpu_total'] = guest['cpus']
+                    guests['guests'][guest['name']]['cpu_total'] = int(guest['cpus'])
                     guests['guests'][guest['name']]['cpu_used'] = guest['cpu'] * guest['cpus']
                     guests['guests'][guest['name']]['memory_total'] = guest['maxmem']
                     guests['guests'][guest['name']]['memory_used'] = guest['mem']
@@ -92,6 +92,8 @@ class Guests:
                     guests['guests'][guest['name']]['ignore'] = Tags.get_ignore(guests['guests'][guest['name']]['tags'])
                     guests['guests'][guest['name']]['node_relationship'] = Tags.get_node_relationship(guests['guests'][guest['name']]['tags'])
                     guests['guests'][guest['name']]['type'] = 'vm'
+
+                    logger.debug(f"Resources of Guest {guest['name']} (type VM) added: {guests['guests'][guest['name']]}")
                 else:
                     logger.debug(f'Metric for VM {guest["name"]} ignored because VM is not running.')
 
@@ -102,7 +104,7 @@ class Guests:
                 if guest['status'] == 'running':
                     guests['guests'][guest['name']] = {}
                     guests['guests'][guest['name']]['name'] = guest['name']
-                    guests['guests'][guest['name']]['cpu_total'] = guest['cpus']
+                    guests['guests'][guest['name']]['cpu_total'] = int(guest['cpus'])
                     guests['guests'][guest['name']]['cpu_used'] = guest['cpu']
                     guests['guests'][guest['name']]['memory_total'] = guest['maxmem']
                     guests['guests'][guest['name']]['memory_used'] = guest['mem']
@@ -118,6 +120,8 @@ class Guests:
                     guests['guests'][guest['name']]['ignore'] = Tags.get_ignore(guests['guests'][guest['name']]['tags'])
                     guests['guests'][guest['name']]['node_relationship'] = Tags.get_node_relationship(guests['guests'][guest['name']]['tags'])
                     guests['guests'][guest['name']]['type'] = 'ct'
+
+                    logger.debug(f"Resources of Guest {guest['name']} (type CT) added: {guests['guests'][guest['name']]}")
                 else:
                     logger.debug(f'Metric for CT {guest["name"]} ignored because CT is not running.')
 


### PR DESCRIPTION
fix: Force type cast guest cpu count to int where in some corner cases a str got returned.

### Bug
In #222 @raymand211092 reported a bug where we might get a string of `cpu_total` instead of an integer when obtaining the resources from the api.

```
Resources of Guest guest1 (type CT) added: {'name': 'guest1', 'cpu_total': '1', 'cpu_used': 0,
Resources of Guest guest2 (type CT) added: {'name': 'guest2', 'cpu_total': 2, 'cpu_>
```

This fails later when calculating the metrics. As a result, the cpu count gets force type casted to integer. This is strange, becasue according to the API (https://pve.proxmox.com/pve-docs/api-viewer/index.html#/nodes/{node}/lxc) it should return a number (int).

Fixes: #222