### PR TITLE
feature:  Use the average CPU consumption of a guest within the last 60 minutes instead of the current CPU usage

### DIFF
--- a/.changelogs/1.1.3/94_cpu_balancing_use_avg_instead_current_consumption.yml
+++ b/.changelogs/1.1.3/94_cpu_balancing_use_avg_instead_current_consumption.yml
@@ -1,0 +1,2 @@
+feature:
+  - Use the average CPU consumption of a guest within the last 60 minutes instead of the current CPU usage (by @philslab-ninja & @gyptazy). [#94]


### PR DESCRIPTION
feature:  Use the average CPU consumption of a guest within the last 60 minutes instead of the current CPU usage

  - Using the current CPU consumption of a guest object is too volatile and does not represent the real usage. Therefore, we use the average consumption of the cpu values within the last 60 minutes.

Thanks-to: @philslab-ninja
Fixes: #94