### PR TITLE
feature: Allow custom (instead of static tcp/8006) API ports for API hosts

### DIFF
--- a/.changelogs/1.1.5/260_allow_custom_api_ports.yml
+++ b/.changelogs/1.1.5/260_allow_custom_api_ports.yml
@@ -1,0 +1,2 @@
+added:
+  - Allow custom API ports instead of fixed tcp/8006 (@gyptazy). [#260]


### PR DESCRIPTION
feature: Allow custom (instead of static tcp/8006) API ports for API hosts


### Validation
```
2025-07-08 08:06:52,585 - ProxLB - DEBUG - Starting: api_connect_get_hosts.
2025-07-08 08:06:52,585 - ProxLB - DEBUG - Starting: test_api_proxmox_host.
2025-07-08 08:06:52,585 - ProxLB - DEBUG - API host uses a custom port: host: lb.gyptazy.de with port tcp/443.
2025-07-08 08:06:52,836 - ProxLB - DEBUG - lb.gyptazy.de is type ipv4.
2025-07-08 08:06:52,837 - ProxLB - DEBUG - Starting: test_api_proxmox_host_ipv4.
2025-07-08 08:06:52,837 - ProxLB - WARNING - Warning: Host lb.gyptazy.de ran into a timeout when connecting on IPv4 for tcp/443.
2025-07-08 08:06:52,889 - ProxLB - DEBUG - Host lb.gyptazy.de is reachable on IPv4 for tcp/443.
2025-07-08 08:06:52,889 - ProxLB - WARNING - SSL certificate validation to host lb.gyptazy.de is deactivated.
2025-07-08 08:06:53,138 - ProxLB - DEBUG - Using username/password authentication.
2025-07-08 08:06:53,138 - ProxLB - INFO - API connection to host lb.gyptazy.de succeeded.
2025-07-08 08:06:53,139 - ProxLB - DEBUG - Finished: api_connect.
```

Fixes: #259
Fixes: #260