### PR TITLE
fix(proxmox-api): Fix stacktrace output when validating permissions on non existing users in Proxmox

### DIFF
--- a/.changelogs/1.1.6/291_fix_stack_trace_no_user_permissions_testing.yml
+++ b/.changelogs/1.1.6/291_fix_stack_trace_no_user_permissions_testing.yml
@@ -1,0 +1,2 @@
+fixed:
+  - Fix stacktrace output when validating permissions on non existing users in Proxmox (@gyptazy). [#291]

--- a/proxlb/utils/proxmox_api.py
+++ b/proxlb/utils/proxmox_api.py
@@ -336,7 +336,15 @@ class ProxmoxApi:
         permissions_available = []
 
         # Get the permissions for the current user/token from API
-        permissions = proxmox_api.access.permissions.get()
+        try:
+            permissions = proxmox_api.access.permissions.get()
+        except proxmoxer.core.ResourceException as api_error:
+            if "no such user" in str(api_error):
+                logger.error("Authentication to Proxmox API not possible: User not known - please check your username and config file.")
+                sys.exit(1)
+            else:
+                logger.error(f"Proxmox API error: {api_error}")
+                sys.exit(1)
 
         # Get all available permissions of the current user/token
         for path, permission in permissions.items():


### PR DESCRIPTION
# General
fix(proxmox-api): Fix stacktrace output when validating permissions on non existing users in Proxmox

Fixes: #291

# Example
We will now get a clearer error message like:
```
2025-08-25 07:50:00,119 - ProxLB - DEBUG - Finished: api_connect.
2025-08-25 07:50:00,119 - ProxLB - DEBUG - Starting: test_api_user_permissions.
2025-08-25 07:50:03,393 - ProxLB - ERROR - Authentication to Proxmox API not possible: User not known
```
