### PR TITLE
feature: Add validation for provided API user token id to avoid confusions

### DIFF
--- a/.changelogs/1.1.6/290_validate_user_token_syntax.yml
+++ b/.changelogs/1.1.6/290_validate_user_token_syntax.yml
@@ -1,0 +1,2 @@
+added:
+  - Add validation for provided API user token id to avoid confusions (@gyptazy). [#291]

--- a/proxlb/utils/proxmox_api.py
+++ b/proxlb/utils/proxmox_api.py
@@ -135,6 +135,14 @@ class ProxmoxApi:
         proxlb_credentials = proxlb_config["proxmox_api"]
         present_auth_pass = "pass" in proxlb_credentials
         present_auth_secret = "token_secret" in proxlb_credentials
+        token_id = proxlb_credentials.get("token_id", None)
+
+        if token_id:
+            non_allowed_chars = ["@", "!"]
+            for char in non_allowed_chars:
+                if char in token_id:
+                    logger.error(f"Wrong user/token format defined. User and token id must be splitted! Please see: https://github.com/gyptazy/ProxLB/blob/main/docs/03_configuration.md#required-permissions-for-a-user")
+                    sys.exit(1)
 
         if present_auth_pass and present_auth_secret:
             logger.critical(f"Username/password and API token authentication are mutal exclusive. Please use only one!")


### PR DESCRIPTION
# General
feature: Add validation for provided API user token id to avoid confusions

Fixes: #290

# Example
It now provides a more sane error message like:
```
2025-08-25 08:05:55,542 - ProxLB - DEBUG - Starting: api_connect.
2025-08-25 08:05:55,542 - ProxLB - DEBUG - Starting: validate_config.
2025-08-25 08:05:55,542 - ProxLB - ERROR - Wrong user/token format defined. User and token id must be splitted! Please see: https://github.com/gyptazy/ProxLB/blob/main/docs/03_configuration.md#required-permissions-for-a-user
```