### PR TITLE
fix: overprovisioning first node if anti_affinity group has only one member

### DIFF
--- a/.changelogs/1.1.6/295_fix_overprovisioning_first_node_if_anti_affinity_group_has_only_one-member.yml
+++ b/.changelogs/1.1.6/295_fix_overprovisioning_first_node_if_anti_affinity_group_has_only_one-member.yml
@@ -1,0 +1,3 @@
+fixed:
+  - Fix Overprovisioning first node if anti_affinity_group has only one member (@MiBUl-eu). [#295]
+  

--- a/proxlb/models/calculations.py
+++ b/proxlb/models/calculations.py
@@ -287,7 +287,7 @@ class Calculations:
                         else:
                             logger.critical(f"Node: {node_name} already got used for anti-affinity group:: {group_name}. (Tried for guest: {guest_name})")
                 else:
-                    logger.debug(f"Anti-Affinity: Group has less than 1 member. Skipping node calucation for the group.")
+                    logger.debug(f"Anti-Affinity: Group has less than 2 members. Skipping node calculation for the group.")
 
             else:
                 logger.debug(f"Guest: {guest_name} is not included in anti-affinity group: {group_name}. Skipping.")


### PR DESCRIPTION
We have found out that if a anti affinity group has only one member. One proxmox host get completly overprovisioned. 

This PR will fix this and will "ignore" the anti affinity group if there is only or less member in it. 

before:
2025-08-25 06:34:10,352 - ProxLB - DEBUG - Nodes usage memory: node1: 102.68% | node2: 36.43% | node3: 24.00%
2025-08-25 06:34:10,352 - ProxLB - DEBUG - Nodes usage cpu:    node1: 11.08%  | node2: 8.99%  | node3: 11.85%
2025-08-25 06:34:10,352 - ProxLB - DEBUG - Nodes usage disk:   node1: 46.81% | node2: 53.42% | node3: 53.42%

after:
2025-08-25 08:04:32,598 - ProxLB - DEBUG - Nodes usage memory: node1: 55.71% | node2: 60.56% | node3: 46.96%
2025-08-25 08:04:32,598 - ProxLB - DEBUG - Nodes usage cpu:    node1: 9.52%  | node2: 12.05%  | node3: 12.40%
2025-08-25 08:04:32,598 - ProxLB - DEBUG - Nodes usage disk:   node1: 46.81% | node2: 53.42% | node3: 53.42%
