### PR TITLE
fix: Validate for node presence when pinning guests to avoid crashing

### DIFF
--- a/.changelogs/1.1.6/296_fix_validate_node_presence_when_pinning_guests.yml
+++ b/.changelogs/1.1.6/296_fix_validate_node_presence_when_pinning_guests.yml
@@ -1,0 +1,3 @@
+fixed:
+  - Validate for node presence when pinning guests to avoid crashing (@gyptazy). [#296]
+  

--- a/proxlb/models/guests.py
+++ b/proxlb/models/guests.py
@@ -107,7 +107,7 @@ class Guests:
                     guests['guests'][guest['name']]['affinity_groups'] = Tags.get_affinity_groups(guests['guests'][guest['name']]['tags'])
                     guests['guests'][guest['name']]['anti_affinity_groups'] = Tags.get_anti_affinity_groups(guests['guests'][guest['name']]['tags'])
                     guests['guests'][guest['name']]['ignore'] = Tags.get_ignore(guests['guests'][guest['name']]['tags'])
-                    guests['guests'][guest['name']]['node_relationships'] = Tags.get_node_relationships(guests['guests'][guest['name']]['tags'])
+                    guests['guests'][guest['name']]['node_relationships'] = Tags.get_node_relationships(guests['guests'][guest['name']]['tags'], nodes)
                     guests['guests'][guest['name']]['type'] = 'ct'
 
                     logger.debug(f"Resources of Guest {guest['name']} (type CT) added: {guests['guests'][guest['name']]}")

--- a/proxlb/utils/helper.py
+++ b/proxlb/utils/helper.py
@@ -265,3 +265,27 @@ class Helper:
                 return parts[0], port
             except ValueError:
                 return host_object, 8006
+
+    @staticmethod
+    def validate_node_presence(node: str, nodes: Dict[str, Any]) -> bool:
+        """
+        Validates whether a given node exists in the provided cluster nodes dictionary.
+
+        Args:
+            node (str): The name of the node to validate.
+            nodes (Dict[str, Any]): A dictionary containing cluster information.
+                                    Must include a "nodes" key mapping to a dict of available nodes.
+
+        Returns:
+            bool: True if the node exists in the cluster, False otherwise.
+        """
+        logger.debug("Starting: validate_node_presence.")
+
+        if node in nodes["nodes"].keys():
+            logger.info(f"Node {node} found in cluster. Applying pinning.")
+            logger.debug("Finished: validate_node_presence.")
+            return True
+        else:
+            logger.warning(f"Node {node} not found in cluster. Not applying pinning!")
+            logger.debug("Finished: validate_node_presence.")
+            return False


### PR DESCRIPTION
fix: Validate for node presence when pinning guests to avoid crashing

Fixes: #296
Fixes: #271