### PR TITLE
Add graceful shutdown for SIGINT (e.g., CTRL + C abort).

### DIFF
--- a/.changelogs/1.1.7/304_add_graceful_shutdown_sigint.yml
+++ b/.changelogs/1.1.7/304_add_graceful_shutdown_sigint.yml
@@ -1,0 +1,2 @@
+added:
+  - Add graceful shutdown for SIGINT (e.g., CTRL + C abort). (@gyptazy). [#304]

--- a/proxlb/main.py
+++ b/proxlb/main.py
@@ -33,8 +33,9 @@ def main():
     # Initialize logging handler
     logger = SystemdLogger(level=logging.INFO)
 
-    # Signal handler for SIGHUP
+    # Initialize handlers
     signal.signal(signal.SIGHUP, Helper.handler_sighup)
+    signal.signal(signal.SIGINT, Helper.handler_sigint)
 
     # Parses arguments passed from the CLI
     cli_parser = CliParser()

--- a/proxlb/utils/helper.py
+++ b/proxlb/utils/helper.py
@@ -16,6 +16,7 @@ import time
 import utils.version
 from utils.logger import SystemdLogger
 from typing import Dict, Any
+from types import FrameType
 
 logger = SystemdLogger()
 
@@ -200,7 +201,7 @@ class Helper:
         logger.debug("Finished: print_json.")
 
     @staticmethod
-    def handler_sighup(signum, frame):
+    def handler_sighup(signum: int, frame: FrameType) -> None:
         """
         Signal handler for SIGHUP.
 
@@ -216,6 +217,23 @@ class Helper:
         logger.debug("Got SIGHUP signal. Reloading...")
         Helper.proxlb_reload = True
         logger.debug("Finished: handle_sighup.")
+
+    @staticmethod
+    def handler_sigint(signum: int, frame: FrameType) -> None:
+        """
+        Signal handler for SIGINT. (triggered by CTRL+C).
+
+        Args:
+            signum (int): The signal number (e.g., SIGINT).
+            frame (FrameType): The current stack frame when the signal was received.
+
+        Returns:
+            None
+        """
+        exit_message = "ProxLB has been successfully terminated by user."
+        logger.debug(exit_message)
+        print(f"\n {exit_message}")
+        sys.exit(0)
 
     @staticmethod
     def get_host_port_from_string(host_object):


### PR DESCRIPTION
Add graceful shutdown for SIGINT (e.g., CTRL + C abort).

### Example
```
 2025-09-15 07:24:19,770 - ProxLB - INFO - Daemon mode active: Next run in: 12 hours.
^C
 ProxLB has been successfully terminated by user.
```

Fixes: #304