### PR TITLE
fix(logging): Add a static ProxLB prefix to the log output when used by journal handler

### DIFF
--- a/.changelogs/1.1.8/318_fix_conntrack_aware_migrations_api_pve8.yml
+++ b/.changelogs/1.1.8/318_fix_conntrack_aware_migrations_api_pve8.yml
@@ -1,2 +1,2 @@
 fixed:
-  - Fix API errors when using conntrack aware migration with older PVE versions. (@gyptazy). [#318]
+  - Fix API errors when using conntrack aware migration with older PVE versions (@gyptazy). [#318]

--- a/.changelogs/1.1.8/329_add_log_prefix.yml
+++ b/.changelogs/1.1.8/329_add_log_prefix.yml
@@ -1,0 +1,2 @@
+fixed:
+  - Add a static ProxLB prefix to the log output when used by journal handler (@gyptazy). [#329]

--- a/proxlb/utils/logger.py
+++ b/proxlb/utils/logger.py
@@ -88,7 +88,7 @@ class SystemdLogger:
         # logging is preferred.
         if SYSTEMD_PRESENT:
             # Add a JournalHandler for systemd integration
-            handler = JournalHandler()
+            handler = JournalHandler(SYSLOG_IDENTIFIER="ProxLB")
         else:
             # Add a stdout handler as a fallback
             handler = logging.StreamHandler(sys.stdout)


### PR DESCRIPTION
fix(logging): Add a static ProxLB prefix to the log output when used by journal handler

Requested by: @mbunkus
Fixes: #329


## Validation

**Before**:
```
Oct 08 18:33:08 dev-proxmox03 /usr/lib/python3/dist-packages/proxlb/main.py[7475]: 2025-10-08 18:33:08,984 - ProxLB - DEBUG - Finished: set_node_ignore.
Oct 08 18:33:08 dev-proxmox03 /usr/lib/python3/dist-packages/proxlb/main.py[7475]: 2025-10-08 18:33:08,984 - ProxLB - DEBUG - Starting: set_node_maintenance.
Oct 08 18:33:08 dev-proxmox03 /usr/lib/python3/dist-packages/proxlb/main.py[7475]: 2025-10-08 18:33:08,984 - ProxLB - DEBUG - Node: dev-proxmox02 is not in maintenance mode by ProxLB config.
Oct 08 18:33:08 dev-proxmox03 /usr/lib/python3/dist-packages/proxlb/main.py[7475]: 2025-10-08 18:33:08,987 - ProxLB - DEBUG - Finished: set_node_maintenance.
Oct 08 18:33:08 dev-proxmox03 /usr/lib/python3/dist-packages/proxlb/main.py[7475]: 2025-10-08 18:33:08,987 - ProxLB - DEBUG - Starting: set_node_ignore.
Oct 08 18:33:08 dev-proxmox03 /usr/lib/python3/dist-packages/proxlb/main.py[7475]: 2025-10-08 18:33:08,987 - ProxLB - DEBUG - Finished: set_node_ignore.
Oct 08 18:33:08 dev-proxmox03 /usr/lib/python3/dist-packages/proxlb/main.py[7475]: 2025-10-08 18:33:08,987 - ProxLB - DEBUG - Starting: set_node_maintenance.
Oct 08 18:33:08 dev-proxmox03 /usr/lib/python3/dist-packages/proxlb/main.py[7475]: 2025-10-08 18:33:08,987 - ProxLB - INFO - Node: dev-proxmox03 has been set to maintenance mode (by ProxLB config).
Oct 08 18:33:08 dev-proxmox03 /usr/lib/python3/dist-packages/proxlb/main.py[7475]: 2025-10-08 18:33:08,987 - ProxLB - DEBUG - Finished: get_nodes.
Oct 08 18:33:08 dev-proxmox03 /usr/lib/python3/dist-packages/proxlb/main.py[7475]: 2025-10-08 18:33:08,987 - ProxLB - DEBUG - Starting: get_guests.
```


**After**:
```
Oct 08 18:33:40 dev-proxmox03 ProxLB[7731]: 2025-10-08 18:33:40,950 - ProxLB - DEBUG - Nodes usage memory: dev-proxmox03: 55.79% | dev-proxmox02: 54.62% | dev-proxmox01: 50.33%
Oct 08 18:33:40 dev-proxmox03 ProxLB[7731]: 2025-10-08 18:33:40,950 - ProxLB - DEBUG - Nodes usage cpu:    dev-proxmox03: 2.16%  | dev-proxmox02: 2.04%  | dev-proxmox01: 2.32%
Oct 08 18:33:40 dev-proxmox03 ProxLB[7731]: 2025-10-08 18:33:40,950 - ProxLB - DEBUG - Nodes usage disk:   dev-proxmox03: 15.99% | dev-proxmox02: 15.98% | dev-proxmox01: 24.18%
Oct 08 18:33:40 dev-proxmox03 ProxLB[7731]: 2025-10-08 18:33:40,950 - ProxLB - DEBUG - Finished: log_node_metrics.
Oct 08 18:33:40 dev-proxmox03 proxlb[7731]: 2025-10-08 18:33:40,950 - ProxLB - DEBUG - Balancing: Parallel balancing is disabled. Running sequentially.
Oct 08 18:33:40 dev-proxmox03 ProxLB[7731]: 2025-10-08 18:33:40,950 - ProxLB - DEBUG - Starting: chunk_dict.
Oct 08 18:33:40 dev-proxmox03 ProxLB[7731]: 2025-10-08 18:33:40,951 - ProxLB - DEBUG - Starting: print_json.
Oct 08 18:33:40 dev-proxmox03 ProxLB[7731]: 2025-10-08 18:33:40,951 - ProxLB - DEBUG - Finished: print_json.
Oct 08 18:33:40 dev-proxmox03 ProxLB[7731]: 2025-10-08 18:33:40,951 - ProxLB - DEBUG - Starting: get_daemon_mode.
Oct 08 18:33:40 dev-proxmox03 ProxLB[7731]: 2025-10-08 18:33:40,951 - ProxLB - INFO - Daemon mode active: Next run in: 12 hours.
```