### PR TITLE
fix(pools): Fixes a crash during PVE resource pool enumeration by ski…

### DIFF
--- a/.changelogs/1.1.10/368_fix_crash_enumerating_pools_with_storage_members.yml
+++ b/.changelogs/1.1.10/368_fix_crash_enumerating_pools_with_storage_members.yml
@@ -1,0 +1,2 @@
+fixed:
+  - Fixed a crash during PVE resource pool enumeration by skipping members not having a 'name' property (@stefanoettl). [#368]

--- a/proxlb/models/pools.py
+++ b/proxlb/models/pools.py
@@ -68,6 +68,12 @@ class Pools:
             # Fetch pool details and collect member names
             pool_details = proxmox_api.pools(pool['poolid']).get()
             for member in pool_details.get("members", []):
+
+                # We might also have objects without the key "name", e.g. storage pools
+                if "name" not in member:
+                    logger.debug(f"Skipping member without name in pool: {pool['poolid']}")
+                    continue
+
                 logger.debug(f"Got member: {member['name']} for pool: {pool['poolid']}")
                 pools['pools'][pool['poolid']]['members'].append(member["name"])
 


### PR DESCRIPTION
fix(pools): Fixes a crash during PVE resource pool enumeration by skipping members not having a 'name' property (i.e. 'storage' members).

Fixes: #368
Sponsored-by: Stefan Oettl <stefan.oettl@isarnet.de> (@stefanoettl)