### PR TITLE
fix: Add missing 'packaging' dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,6 +7,6 @@ Build-Depends: debhelper-compat (= 13), dh-python, python3-all, python3-setuptoo
 
 Package: proxlb
 Architecture: all
-Depends: ${python3:Depends}, ${misc:Depends}, python3-requests, python3-urllib3, python3-proxmoxer, python3-yaml 
+Depends: ${python3:Depends}, ${misc:Depends}, python3-requests, python3-urllib3, python3-packaging, python3-proxmoxer, python3-yaml
 Description: An advanced resource scheduler and load balancer for Proxmox clusters
  An advanced resource scheduler and load balancer for Proxmox clusters that also supports maintenance mode and affinity/anti-affinity rules.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+packaging
 proxmoxer
 requests
 urllib3


### PR DESCRIPTION
fix: Add missing 'packaging' dependency
Sponsored-by: Stefan Oettl <stefan.oettl@isarnet.de> (@stefanoettl)