### PR TITLE
Fix enforce_affinity boolean inversion

### DIFF
--- a/.changelogs/1.1.11/335_fix_affinity_matrix_prevalidation.yml
+++ b/.changelogs/1.1.11/335_fix_affinity_matrix_prevalidation.yml
@@ -1,0 +1,2 @@
+fixed:
+  - Fixed affinity matrix pre-validation by inverting validations (@Thalagyrt). [#335]

--- a/proxlb/models/calculations.py
+++ b/proxlb/models/calculations.py
@@ -605,7 +605,7 @@ class Calculations:
             logger.debug(f"Affinity for guest {guest} is {'valid' if balancing_state_affinity else 'NOT valid'}")
             logger.debug(f"Anti-affinity for guest {guest} is {'valid' if balancing_state_anti_affinity else 'NOT valid'}")
 
-            balancing_ok = not balancing_state_affinity or not balancing_state_anti_affinity
+            balancing_ok = balancing_state_affinity and balancing_state_anti_affinity
 
         if balancing_ok:
             logger.debug(f"Rebalancing based on affinity/anti-affinity map is not required.")


### PR DESCRIPTION
During runs in which affinity checks determine balancing actions, there was a small error in a boolean calculation that caused ProxLB to always rebalance, as it exited the verification loop with a failure the first time it saw a VM that actually passed affinity checks.

Fixes: #335

Apologies, unsure what to do on changelogs, as the directories there seem to only mention existing releases - is there something I'm missing to note this patch down? I also ran flake8 locally per contributing.md, and it complained about nearly every file, and pytest in the repo root said no tests run, so I figure CI may be configured to do something different there. If anything fails on this PR I'll fix it after CI runs it. :)