### PR TITLE
feature: Add possibility to sort and select balancing workloads by smaller/larger guest objects

### DIFF
--- a/.changelogs/1.1.11/387_select_balancing_workloads_by_size.yml
+++ b/.changelogs/1.1.11/387_select_balancing_workloads_by_size.yml
@@ -1,0 +1,2 @@
+added:
+  - Add possibility to sort and select balancing workloads by smaller/larger guest objects (@gyptazy). [#387]

--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ The following options can be set in the configuration file `proxlb.yaml`:
 |  | memory_threshold |  | 75 | `Int` | The maximum threshold (in percent) that needs to be hit to perform balancing actions. (Optional) |
 |  | method |  | memory | `Str` | The balancing method that should be used.  [values: `memory` (default), `cpu`, `disk`]|
 |  | mode |  | used | `Str` | The balancing mode that should be used. [values: `used` (default), `assigned`, `psi` (pressure)] |
+|  | balance_larger_guests_first |  | False | `Bool` | Option to prefer larger/smaller guests first |
 |  | psi |  | { nodes: { memory: { pressure_full: 0.20, pressure_some: 0.20, pressure_spikes: 1.00 }}} | `Dict` | A dict of PSI based thresholds for nodes and guests |
 |  | pools |  | pools: { dev: { type: affinity }, de-nbg01-db: { type: anti-affinity }} | `Dict` | A dict of pool names and their type for creating affinity/anti-affinity rules |
 | `service` |  |  |  |  |  |
@@ -336,6 +337,7 @@ balancing:
   balanciness: 5
   method: memory
   mode: used
+  balance_larger_guests_first: False
 # # PSI thresholds only apply when using mode 'psi'
 # # PSI based balancing is currently in beta and req. PVE >= 9
 # psi:

--- a/config/proxlb_example.yaml
+++ b/config/proxlb_example.yaml
@@ -32,6 +32,7 @@ balancing:
   balanciness: 5                      # Maximum delta of resource usage between highest and lowest usage node
   method: memory                      # 'memory' | 'cpu' | 'disk'
   mode: used                          # 'assigned' | 'used' | 'psi'
+  balance_larger_guests_first: False  # Option to prioritize balancing of larger or smaller guests first
   # # PSI thresholds only apply when using mode 'psi'
   # psi:
   #   nodes:

--- a/proxlb/models/calculations.py
+++ b/proxlb/models/calculations.py
@@ -377,7 +377,19 @@ class Calculations:
             if proxlb_data["meta"]["balancing"].get("enforce_affinity", False):
                 logger.debug("Balancing of guests will be performed. Reason: enforce affinity balancing")
 
-            for group_name in proxlb_data["groups"]["affinity"]:
+            # Sort guests by used memory
+            # Allows processing larger guests first or smaller guests first
+            larger_first = proxlb_data.get("meta", {}).get("balancing", {}).get("balance_larger_guests_first", False)
+
+            if larger_first:
+                logger.debug("Larger guests will be processed first. (Sorting descending by memory used)")
+            else:
+                logger.debug("Smaller guests will be processed first. (Sorting ascending by memory used)")
+
+            sorted_guest_usage_groups = sorted(proxlb_data["groups"]["affinity"], key=lambda g: proxlb_data["groups"]["affinity"][g]["memory_used"], reverse=larger_first)
+
+            # Iterate over all affinity groups
+            for group_name in sorted_guest_usage_groups:
 
                 # We get initially the node with the most free resources and then
                 # migrate all guests within the group to that node to ensure the


### PR DESCRIPTION
feature: Add possibility to sort and select balancing workloads by smaller/larger guest objects

  - Allows operators to select if first larger or smaller workloads should be migrated

Fixes: #387