### PR TITLE
feature(calculation): Run calculations only until the used node is not the one with the highest usage anymore.

### DIFF
--- a/proxlb/models/tags.py
+++ b/proxlb/models/tags.py
@@ -248,7 +248,8 @@ class Tags:
                 if pool in (proxlb_config['balancing'].get('pools') or {}):
 
                     pool_nodes = proxlb_config['balancing']['pools'][pool].get('pin', None)
-                    for node in pool_nodes:
+                    print(pool_nodes)
+                    for node in pool_nodes if pool_nodes is not None else []:
 
                         # Validate if the node to pin is present in the cluster
                         if Helper.validate_node_presence(node, nodes):


### PR DESCRIPTION
feature(calculation): Run calculations only until the used node is not the one with the highest usage anymore.

 * Run balancing calculations only until the used node is not the one with the highest usage anymore.
   * Avoiding more relocation
   * Avoiding "insane" outputs in smaller clusters
 * Fix pool based node pinning when empty

Fixes: #395
Fixes: #390