### PR TITLE
Change balancing and sorting behaviour of guests

### DIFF
--- a/.changelogs/1.1.11/378_change_and_improve_balancing_decisions.yml
+++ b/.changelogs/1.1.11/378_change_and_improve_balancing_decisions.yml
@@ -1,0 +1,3 @@
+changed:
+  - Changed balancing and sorting behaviour (@gyptazy). [#378]
+  - Balancing objects will be ordered by: count of objects in affinity-rules, followed by memory size 


### PR DESCRIPTION
  - Sort to be balanced guests first by size of affinity group (ASC)
  - Sort to be balanced guests afterwards by used memory size (ASC/DESC)
  - Validate if lowest used node is still the lowest one

Fixes: #378
Fixes: #390